### PR TITLE
Setting up ci testing, ruff and pre-commit

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,42 @@
+name: CI
+
+on:
+  push:
+    paths:
+      - "**"
+      - "!.github/**"
+      - ".github/workflows/ci.yml"
+  pull_request:
+    paths:
+      - "**"
+      - "!.github/**"
+      - ".github/workflows/ci.yml"
+  workflow_dispatch:
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    strategy:
+      matrix:
+        python-version: ["pypy3.10", "3.9", "3.10", "3.11", "3.12", "3.13"]
+
+    steps:
+    - uses: actions/checkout@v4
+    - name: Set up Python ${{ matrix.python-version }}
+      uses: actions/setup-python@v5
+      with:
+        python-version: ${{ matrix.python-version }}
+        # You can test your matrix by printing the current Python version
+    - name: Display Python version
+      run: python -c "import sys; print(sys.version)"
+    - name: Install dependencies
+      run: |
+        python -m pip install --upgrade pip
+        python -m pip install ".[tests]"
+    # Update output format to enable automatic inline annotations
+    - name: Run Ruff
+      run: ruff check --output-format=github .
+    - name: Test with pytest
+      run: |
+        python -m pytest --cov=mygeopy --cov-report=xml --cov-report=html .
+

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,0 +1,10 @@
+repos:
+- repo: https://github.com/astral-sh/ruff-pre-commit
+  # Ruff version
+  rev: v0.12.9
+  hooks:
+    # Run the linter.
+    - id: ruff-check
+      args: [ --fix ]
+    # Run the formatter.
+    - id: ruff-format

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -15,13 +15,21 @@ dependencies = [
   "numpy >= 2",
   "scipy >= 1.4",
   "unyt >= 3",
+  "CLASSICS @ git+https://github.com/kahlhoefer/CLASSICS.git"
 ]
 dynamic = ["version","readme"]
+
+[project.optional-dependencies]
+dev = ["pre-commit"]
+tests = [dev,"pytest", "pytest-cov"]
 
 [project.urls]
 home = "https://github.com/mtryan83/sidm-vdsigmas"
 source = "https://github.com/mtryan83/sidm-vdsigmas"
 issues = "https://github.com/mtryan83/sidm-vdisgmas/issues/new"
+
+[tool.setuptools]
+packages = ["sidm_vdsigmas"]
 
 [tool.setuptools.dynamic]
 readme = {file = ["README.md"]}

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -21,7 +21,7 @@ dynamic = ["version","readme"]
 
 [project.optional-dependencies]
 dev = ["pre-commit"]
-tests = [dev,"pytest", "pytest-cov"]
+tests = ["dev", "pytest", "pytest-cov"]
 
 [project.urls]
 home = "https://github.com/mtryan83/sidm-vdsigmas"


### PR DESCRIPTION
Initial workflows for CI testing and Ruff linting/fixing. Note that CLASSICs doesn't currently exist as an installable project, so installing dependencies fails in the CI pipeline. Of course, there aren't any tests yet, so it's a moot point.