### PR TITLE
BUG: Need to manually specify packages now

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -23,6 +23,9 @@ home = "https://github.com/mtryan83/sidm-vdsigmas"
 source = "https://github.com/mtryan83/sidm-vdsigmas"
 issues = "https://github.com/mtryan83/sidm-vdisgmas/issues/new"
 
+[tool.setuptools]
+packages = ["sidm_vdsigmas", "CLASSICS",]
+
 [tool.setuptools.dynamic]
 readme = {file = ["README.md"]}
 


### PR DESCRIPTION
Since we're using the flat file structure, setuptools won't do automatic discovery with two top-level modules. Need to manually specify them.